### PR TITLE
Checkpoints and jump/double jump enabling in editor

### DIFF
--- a/Hellevator/Assets/GameAssets/Prefabs/Levels/CheckPoint.prefab
+++ b/Hellevator/Assets/GameAssets/Prefabs/Levels/CheckPoint.prefab
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8028671402884467283
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8028671402884467286}
+  - component: {fileID: 8028671402884467281}
+  - component: {fileID: 8028671402884467280}
+  m_Layer: 2
+  m_Name: CheckPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8028671402884467286
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8028671402884467283}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 152.06, y: -3.96, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &8028671402884467281
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8028671402884467283}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.16347218}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 3.2886295}
+  m_EdgeRadius: 0
+--- !u!114 &8028671402884467280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8028671402884467283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85d088ae25671f947b16516ef3b12307, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  demonToSpawn: {fileID: 1676767983, guid: 8f00afffef3953d47a6d48274a6ff0f5, type: 3}

--- a/Hellevator/Assets/GameAssets/Prefabs/Levels/CheckPoint.prefab.meta
+++ b/Hellevator/Assets/GameAssets/Prefabs/Levels/CheckPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 43bf4d977f5eeba439cc109324614ef3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Hellevator/Assets/GameAssets/Scripts/Camera/CameraChangeOnTrigger.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/Camera/CameraChangeOnTrigger.cs
@@ -16,7 +16,7 @@ public class CameraChangeOnTrigger : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        print("dentroTrigger");
+
         if (collision.transform.root.GetComponent<DemonBase>() == PosesionManager.Instance.ControlledDemon)
         {
             print(collision.transform.root.GetComponent<DemonBase>());
@@ -43,7 +43,6 @@ public class CameraChangeOnTrigger : MonoBehaviour
     {
         if (collision.transform.root.GetComponent<DemonBase>() == PosesionManager.Instance.ControlledDemon)
         {
-            print("FueraTrigger");
 
             if (cameraManager.Camera1.activeSelf == true)
             {

--- a/Hellevator/Assets/GameAssets/Scripts/Demons/BasicZombie.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/Demons/BasicZombie.cs
@@ -11,6 +11,10 @@ public class BasicZombie : DemonBase
     [SerializeField] private float m_maxSpeed;
     [SerializeField] private float m_acceleration = 7;
     [SerializeField] private float m_jumpForce = 10;
+    [SerializeField] private bool m_canJump;
+    [SerializeField] private bool m_canDoubleJump;
+    private bool m_hasJumped;
+    private bool m_hasDoubleJumped;
 
     [Header("References")]
     [SerializeField] ParticleSystem walkingParticles;
@@ -91,10 +95,20 @@ public class BasicZombie : DemonBase
 
     public override void Jump()
     {
-        if (IsGrounded())
-        {            
-            MyRgb.velocity = new Vector2(MyRgb.velocity.x, 0);
-            MyRgb.AddForce(Vector2.up * JumpForce);
+        if (m_canJump)
+        {
+            if (!m_hasJumped)
+            {
+                MyRgb.velocity = new Vector2(MyRgb.velocity.x, 0);
+                MyRgb.AddForce(Vector2.up * JumpForce);
+                m_hasJumped = true;
+            }
+            else if(m_canDoubleJump && !m_hasDoubleJumped)
+            {
+                MyRgb.velocity = new Vector2(MyRgb.velocity.x, 0);
+                MyRgb.AddForce(Vector2.up * JumpForce);
+                m_hasDoubleJumped = true;
+            }
         }
     }
     
@@ -107,6 +121,20 @@ public class BasicZombie : DemonBase
         else
         {
             walkingParticles.Stop();
+        }
+    }
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (IsGrounded())
+        {
+            if (m_canJump)
+            {
+                m_hasJumped = false;
+                if (m_canDoubleJump)
+                {
+                    m_hasDoubleJumped = false;
+                }
+            }
         }
     }
 }

--- a/Hellevator/Assets/GameAssets/Scripts/LevelElements/CheckPoint.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/LevelElements/CheckPoint.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent (typeof (Collider2D))]
+public class CheckPoint : MonoBehaviour
+{
+
+    [SerializeField] private DemonBase demonToSpawn;
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if(collision.transform.root.GetComponent<DemonBase>() == PosesionManager.Instance.ControlledDemon)
+        {
+            LevelManager.Instance.SetLastCheckPoint(this);
+        }
+    }
+
+    /// <summary>
+    /// Spawns player at checkpoint location, summoning and possessing the instantiated type of demon
+    /// </summary>
+    public void SpawnPlayer()
+    {
+        DemonBase spawnedDemon = Instantiate(demonToSpawn, transform.position, Quaternion.identity);
+        spawnedDemon.enabled = true;
+        spawnedDemon.SetControlledByPlayer();
+        CameraManager.Instance.ChangeCamTarget();
+        InputManager.Instance.UpdateDemonReference();
+    }
+}

--- a/Hellevator/Assets/GameAssets/Scripts/LevelElements/CheckPoint.cs.meta
+++ b/Hellevator/Assets/GameAssets/Scripts/LevelElements/CheckPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85d088ae25671f947b16516ef3b12307
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Hellevator/Assets/GameAssets/Scripts/Managers/InputManager.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/Managers/InputManager.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.SceneManagement;
 
 public class InputManager : PersistentSingleton<InputManager>
 {
@@ -58,7 +57,7 @@ public class InputManager : PersistentSingleton<InputManager>
 
         if (Input.GetKeyDown(KeyCode.Escape))
         {
-            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            LevelManager.Instance.RestartLevel();
         }
     }
 

--- a/Hellevator/Assets/GameAssets/Scripts/Managers/LevelManager.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/Managers/LevelManager.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class LevelManager : PersistentSingleton<LevelManager>
+{
+    public List<Vector3> m_checkPoints;
+
+    public CheckPoint m_lastCheckPoint;
+
+    private bool m_isRestarting;
+
+    AsyncOperation m_loadingScene;
+
+    public CheckPoint LastCheckPoint { get => m_lastCheckPoint;
+
+        set
+        {
+            m_lastCheckPoint = value;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the checkpoint has been already entered
+    /// </summary>
+    /// <param name="value">The checkpoint to check</param>
+    public void SetLastCheckPoint(CheckPoint value)
+    {
+        if (m_checkPoints == null)
+        {
+            m_checkPoints = new List<Vector3>();
+        }
+        bool foundInside = false;
+        for (int i = 0; i < m_checkPoints.Count; i++)
+        {
+            if(m_checkPoints[i] == value.transform.position)
+            {
+                foundInside = true;
+            }
+        }
+        if (!foundInside)
+        {
+            m_checkPoints.Add(value.transform.position);
+            m_lastCheckPoint = value;
+        }
+    }
+
+    private void Update()
+    {
+        if (m_isRestarting)
+        {
+            if (m_loadingScene.isDone)
+            {
+                PosesionManager.Instance.ControlledDemon.SetNotControlledByPlayer();
+                UpdateLastCheckPointReference();
+                m_lastCheckPoint.SpawnPlayer();
+                m_isRestarting = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Picks up the reference again of the last entered checkpoint among all checkpoints
+    /// </summary>
+    private void UpdateLastCheckPointReference()
+    {
+        CheckPoint[] cps = FindObjectsOfType<CheckPoint>();
+
+        for (int i = 0; i < cps.Length; i++)
+        {
+            if(m_checkPoints[m_checkPoints.Count-1] == cps[i].transform.position)
+            {
+                m_lastCheckPoint = cps[i];
+                return;
+            }
+        }
+        
+    }
+
+    /// <summary>
+    /// Resets the level and spawns the player at the checkpoints
+    /// </summary>
+    public void RestartLevel()
+    {
+        m_loadingScene = SceneManager.LoadSceneAsync(SceneManager.GetActiveScene().buildIndex);
+        m_isRestarting = true;        
+    }
+}

--- a/Hellevator/Assets/GameAssets/Scripts/Managers/LevelManager.cs.meta
+++ b/Hellevator/Assets/GameAssets/Scripts/Managers/LevelManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28436af7ac6a6a149b55b765c0b205f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Hellevator/Assets/GameAssets/Scripts/Managers/PosesionManager.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/Managers/PosesionManager.cs
@@ -63,7 +63,7 @@ public class PosesionManager : TemporalSingleton<PosesionManager>
         }
         else
         {
-            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            LevelManager.Instance.RestartLevel();
         }
     }
 }

--- a/Hellevator/Assets/GameAssets/Scripts/ParentClasses/Characters/DemonBase.cs
+++ b/Hellevator/Assets/GameAssets/Scripts/ParentClasses/Characters/DemonBase.cs
@@ -280,6 +280,7 @@ public abstract class DemonBase : MonoBehaviour
     /// </summary>
     private void LerpResetRagdollTransforms()
     {
+        IsControlledByPlayer = true;
         Transform torso = m_limbsColliders[0].transform;
         if (!m_hasResetParentPosition)
         {
@@ -311,7 +312,7 @@ public abstract class DemonBase : MonoBehaviour
         {
             ResetRagdollTransforms();
             m_isLerpingToResetBones = false;
-            IsControlledByPlayer = true;
+            
             m_hasResetParentPosition = false;
         }
     }


### PR DESCRIPTION
Checkpoints added, trigger that is added to a list in level manager, checks to restart level and spawn player at the location of the last added checkpoint. Grounded check is now done at collision enter for jump check